### PR TITLE
add Cloud Run button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Urly Wurly is an URL shortener build on GCP Cloud Run
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=infrastructure)
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=container)
 
 ## What Is It
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Urly Wurly is an URL shortener build on GCP Cloud Run
 
-![Urly-Wurly Logo](logo.png)
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?dir=infrastructure)
 
 ## What Is It
 


### PR DESCRIPTION
This adds a 'Run on Cloud Run' button to the readme. You can simply click it and a Cloud Shell will launch in your own GCP Project, build the container and deploy it on Cloud Run

