### PR TITLE
remove stale backlog.md

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,9 +1,0 @@
-# Feature Backlog
-
-## TODO
-
-* users dashboard (but this will take a while) with link metrics
-
-* send authenticated user context to backend and associate with GCS object metadata
-
-* blog about it


### PR DESCRIPTION
This PR removes the old backlog.md file. It is superseeded by github issues.